### PR TITLE
Make language a bit more transparent on our splash page

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,13 +26,6 @@
 
 </head>
 <body style="background-color:#E4E6E5">
-	<nav class="navbar navbar-default" style="margin-bottom:0;">
-	  <div class="container-fluid">
-	    <div class="col-xs-12 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3">
-	        <p class="navbar-brand" style="padding: 0; margin: 15px 0 5px 0; line-height: 1.2; height: auto;">Apply for Food Stamps in California</p>
-	    </div>
-	  </div>
-	</nav>
 
 <%= yield %>
 

--- a/app/views/user_submissions/new.html.erb
+++ b/app/views/user_submissions/new.html.erb
@@ -2,7 +2,7 @@
   <div class="container-fluid">
     <div class="col-xs-12 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3">
         <h2>Get Extra Money for Groceries Every Month</h2>
-        <p>Take the first step. Apply for CalFresh today.</p>
+        <p>Apply for CalFresh<br>(California's food stamp program)</p>
         <br>
     </div>
   </div>
@@ -22,8 +22,10 @@
             </div>
           </div>
       <% end %>
-      <h3>Get Started</h3>
-      <p>To begin, enter your contact information. We’ll only use this to follow up with you and see if you had any problems applying.</p>
+      <br>
+      <p>We’re a non-profit working to improve the online application for CalFresh.</p>
+      <p>To start applying, fill out the info below.</p>
+      <p>We will <b>only</b> use this to follow up with you and see if you had any problems.</p>
       <div class="form-group">
         <%= submission.label :county %>
         <%= submission.select :county, options_for_select(@counties), {prompt: 'What county do you live in?' },  {required: 'true', autofocus: 'true', class: 'form-control'} %>
@@ -40,7 +42,7 @@
         <%= submission.submit "Start application", class: "btn btn-primary" %>
       </div>
       <div class="form-group">
-        <p style="font-size: 80%; font-style: italic;">A free, non-profit service for California residents.</p>
+        <p style="font-size: 80%; font-style: italic;">A free, non-profit service for California residents by <a href="https://www.codeforamerica.org">Code for America</a>.</p>
       </div>
     </div>
     <% end %>


### PR DESCRIPTION
Tweaked the language and design a bit to make it clearer to folks what we're doing, hopefully up conversion. New look:

![screen shot 2016-03-21 at 2 44 11 pm](https://cloud.githubusercontent.com/assets/994938/13935261/a38566d0-ef73-11e5-96ef-7d8c7d9f2998.png)

![screen shot 2016-03-21 at 2 44 31 pm](https://cloud.githubusercontent.com/assets/994938/13935260/a119aabe-ef73-11e5-93fb-5ef441baf802.png)

cc @matthewloveless @alanjosephwilliams feel free to suggest/make additional improvements in a new PR. I also say "Code for America" at the bottom with a link. I know this may be slightly different from our GetCalFresh wording in the reminders, but I think it improves it. We can tweak further.
